### PR TITLE
Support decoded multilingual category slugs

### DIFF
--- a/no-category-base-wpml.php
+++ b/no-category-base-wpml.php
@@ -107,9 +107,14 @@ function no_category_base_rewrite_rules($category_rewrite) {
 			$category_nicename = get_category_parents( $category->parent, false, '/', true ) . $category_nicename;
 		}
 
-		$category_rewrite["({$category_nicename}(?:/.+)?)/(?:feed/)?(feed|rdf|rss|rss2|atom)/?$"] = 'index.php?category_name=$matches[1]&feed=$matches[2]';
-		$category_rewrite["({$category_nicename}(?:/.+)?)/{$wp_rewrite->pagination_base}/?([0-9]{1,})/?$"] = 'index.php?category_name=$matches[1]&paged=$matches[2]';
-		$category_rewrite["({$category_nicename}(?:/.+)?)/?$"] = 'index.php?category_name=$matches[1]';
+    $decoded_category_nicename = urldecode( $category_nicename );
+		$category_slugs = array_unique( array( $category_nicename, $decoded_category_nicename ) );
+
+		foreach( $category_slugs as $category_slug ) {
+			$category_rewrite["({$category_slug}(?:/.+)?)/(?:feed/)?(feed|rdf|rss|rss2|atom)/?$"] = 'index.php?category_name=$matches[1]&feed=$matches[2]';
+			$category_rewrite["({$category_slug}(?:/.+)?)/{$wp_rewrite->pagination_base}/?([0-9]{1,})/?$"] = 'index.php?category_name=$matches[1]&paged=$matches[2]';
+			$category_rewrite["({$category_slug}(?:/.+)?)/?$"] = 'index.php?category_name=$matches[1]';
+		}
 	}
 
 	// Redirect support from Old Category Base


### PR DESCRIPTION
Sometimes navigating to a category whose slug has non-ansi characters would fail and return a 404 error.

This seems to happen because the rewrite rules only include the url-encoded version of the slug but there are some cases where the evaluated slug is not encoded so the rules fail to match the slug. It's not clear why that happens but a cursory search for solutions returned other cases that do not appear to be similar to the one we encountered. For example, this particular site uses polylang, which may or not be related, as well as a bunch of other plugins. Other cases we found online had different combinations of plugins.

This solution adds an additional set of identical rewrite rules for the decoded version of the "nice" url-encoded category slug.